### PR TITLE
Fix a compiling warning

### DIFF
--- a/find-by-pinyin-dired.el
+++ b/find-by-pinyin-dired.el
@@ -59,8 +59,8 @@ PATTERN is sequence of first character of PinYin from Chinese file name."
   (interactive
    "DFind-name (directory): \nsFind-name (first characters of Hanzi Pinyin): ")
 
-  (let ((regexp ".*"))
-    (dotimes (i (length pattern) str)
+  (let ((regexp ".*") str)
+    (dotimes (i (length pattern))
       (setq str (nth (- (aref pattern i) 97) fbpd-char-table))
       (setq regexp (concat regexp str ".*")))
     ;; find-lisp-find-dired is a lisp version


### PR DESCRIPTION
The compiling warning is

```
In find-by-pinyin-dired:
find-by-pinyin-dired.el:64:13:Warning: assignment to free variable `str'
find-by-pinyin-dired.el:65:35:Warning: reference to free variable `str'
```
